### PR TITLE
add Toggl to time tracking slide

### DIFF
--- a/uva/course-introduction-fall.html
+++ b/uva/course-introduction-fall.html
@@ -342,6 +342,7 @@
 - You MUST keep track of your time for this course (once projects start)
   - It will be entered via a custom system accessed through Collab -> SLP Admin, or directly through netbadge
 - Not keeping track of time will incur a grade penalty!
+  - A helpful (free) tool for time tracking across projects/tasks and platforms is <a href="https://www.toggl.com/">Toggl</a>. 
 - However, to prevent time inflation, I make this guarantee to you:
   - I will NEVER use the amount of time you enter to determine any part of your grade for this course (or the spring course)
 - You are on your honor to enter time accurately


### PR DESCRIPTION
#### What/Why
We are required to track time. [Toggl](https://www.toggl.com/) is a really great [free!] tool that allows you to easily track time and work spans with custom labels. At the end of each week it sends you a really nice report summary of all your hours and you can also log into the dashboard to see cool graphs and such of your time (with breakdown by labels!!).

#### Changes
* added bullet point with link to Toggl's website (see diff). Slide url `uva/course-introduction-fall.html#/5/12`


#### Notes
It has apps desktop apps for all major OSs and mobile platforms as well as a web app and you don't need internet for the native apps to work, so it makes it so easy to track time that there is literally no reason for anyone to forget. And it makes pretty graphs. I've found it also helps me be especially focused and not get sidetracked while I have the timer running for a given task, could do the same for others.

#### Testing
* Look at the slide, make sure it renders correctly
* I don't know of any unit/functional/CI tests for this repo

